### PR TITLE
chore(renovate): migrate Maven updates from Dependabot to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,21 +4,7 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
-registries:
-  maven-dboeckli:
-    type: maven-repository
-    url: https://maven.pkg.github.com/dboeckli
-    username: dboeckli@gmail.com
-    password: ${{secrets.DBOECKLI_GITHUB_ACCESS_TOKEN}}
 updates:
-  - package-ecosystem: maven
-    directory: "/"
-    schedule:
-      interval: daily
-    registries:
-      - maven-dboeckli
-    ignore:
-      - dependency-name: org.apache.maven:*
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,7 @@
         }
     },
     "enabledManagers": [
+        "maven",
         "maven-wrapper",
         "docker-compose",
         "kubernetes",
@@ -52,6 +53,16 @@
         ]
     },
     "packageRules": [
+        {
+            "description": "Ignore Maven APIs/SPIs",
+            "matchDatasources": [
+                "maven"
+            ],
+            "matchPackageNames": [
+                "org.apache.maven:*"
+            ],
+            "enabled": false
+        },
         {
             "matchCategories": [
                 "docker"


### PR DESCRIPTION
Migriert den Maven-Dependency-Scan von Dependabot auf Renovate (siehe opencode-sandbox-kit#63).

- .github/dependabot.yml: Maven-package-ecosystem + registries.maven-dboeckli entfernt, nur github-actions behalten
- .github/renovate.json: "maven" in enabledManagers ergänzt
- .github/renovate.json: packageRule Ignore Maven APIs/SPIs (org.apache.maven:* -> enabled: false) übernommen